### PR TITLE
Update heat-glance-image.yaml

### DIFF
--- a/heat-glance-image.yaml
+++ b/heat-glance-image.yaml
@@ -4,7 +4,7 @@ resources:
   the_resource:
     type: OS::Glance::Image
     properties:
-      container_format: ova
+      container_format: bare
       disk_format: qcow2
       is_public: True
       # location: String


### PR DESCRIPTION
Container format for qcow2 images is bare, don't have any metadata associated with it
